### PR TITLE
Fix package architecture (armhf) does not match system (armel)

### DIFF
--- a/LCD35-show
+++ b/LCD35-show
@@ -44,8 +44,7 @@ if [[ "$version" < "2020.2" ]]; then
 echo "reboot"
 else
 echo "need to update touch configuration"
-sudo dpkg -i -B ./xserver-xorg-input-evdev_1%3a2.10.6-2_armhf.deb 2> error_output.txt
-##sudo apt-get install xserver-xorg-input-evdev  2> error_output.txt
+sudo apt-get install xserver-xorg-input-evdev  2> error_output.txt
 result=`cat ./error_output.txt`
 echo -e "\033[31m$result\033[0m"
 grep -q "error:" ./error_output.txt && exit


### PR DESCRIPTION
This PR resolves https://github.com/lcdwiki/LCD-show-kali/issues/11.